### PR TITLE
fix: add player spawn grace period

### DIFF
--- a/src/entities/Enemy.ts
+++ b/src/entities/Enemy.ts
@@ -97,6 +97,8 @@ export default class Enemy extends Phaser.GameObjects.Sprite {
     const playerRect = insetRect(this.player.getBounds(), 0.2, 0.25);
     const enemyRect = insetRect(this.getBounds(), 0.28, 0.35);
 
+    if (this.player.invulnerable) return;
+
     if (Phaser.Geom.Intersects.RectangleToRectangle(playerRect, enemyRect)) {
       return this.emit('kill');
     }

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -14,7 +14,10 @@ export default class Player extends Phaser.GameObjects.Sprite {
   moveFriction: number;
   horizontalVelocity: number;
   dead: boolean;
+  invulnerable: boolean;
   keys?: PlayerKeys;
+  spawnGraceTimer?: Phaser.Time.TimerEvent;
+  spawnGraceTween?: Phaser.Tweens.Tween;
 
   constructor(scene: Phaser.Scene, x: number, y: number) {
     super(scene, x, y, 'player');
@@ -27,6 +30,7 @@ export default class Player extends Phaser.GameObjects.Sprite {
     this.moveFriction = 1800;
     this.horizontalVelocity = 0;
     this.dead = false;
+    this.invulnerable = false;
 
     // Optional keyboard controls (desktop): arrows / A-D (and Space to move right).
     // Guarded so this doesn't break in environments without the keyboard plugin.
@@ -104,8 +108,36 @@ export default class Player extends Phaser.GameObjects.Sprite {
     this.emit('dead');
   }
 
+  startSpawnGrace(durationMs: number = 600) {
+    this.endSpawnGrace();
+    this.invulnerable = true;
+
+    this.spawnGraceTween = this.scene.tweens.add({
+      targets: this,
+      alpha: 0.45,
+      duration: 90,
+      ease: 'Sine.easeInOut',
+      yoyo: true,
+      repeat: -1
+    });
+
+    this.spawnGraceTimer = this.scene.time.delayedCall(durationMs, () => {
+      this.endSpawnGrace();
+    });
+  }
+
+  endSpawnGrace() {
+    this.invulnerable = false;
+    this.spawnGraceTimer?.remove(false);
+    this.spawnGraceTimer = undefined;
+    this.spawnGraceTween?.stop();
+    this.spawnGraceTween = undefined;
+    this.setAlpha(1);
+  }
+
   restart() {
     this.dead = false;
     this.horizontalVelocity = 0;
+    this.endSpawnGrace();
   }
 }

--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -3,6 +3,8 @@ import Enemy from '../entities/Enemy';
 import Player from '../entities/Player';
 import Goal from '../entities/Goal';
 
+const SPAWN_GRACE_MS = 600;
+
 export default class Demo extends Phaser.Scene {
   player: Player;
   enemy: Enemy;
@@ -70,6 +72,7 @@ export default class Demo extends Phaser.Scene {
 
   createPlayer() {
     this.player = new Player(this, 50, 180);
+    this.player.startSpawnGrace(SPAWN_GRACE_MS);
     this.player.on('dead', () => {
       this.gameOver();
     });


### PR DESCRIPTION
## What
Adds a short spawn grace period after each scene start/restart so the player can’t die instantly if an enemy overlaps the spawn lane.

## Changes
- Player gets ~600ms of invulnerability on spawn (with a subtle blink) and clears it automatically.
- Enemy collision kills are ignored while the player is in the spawn grace window.

## Why
Improves fairness and reduces “instant death” frustration, keeping the retry loop fast and readable.
