### PR TITLE
feat: ease first run enemy density

### DIFF
--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -81,7 +81,9 @@ export default class Demo extends Phaser.Scene {
   createEnemies() {
     // Mild difficulty ramp: each consecutive win increases enemy speed a bit.
     const speedMultiplier = Phaser.Math.Clamp(1 + this.winStreak * 0.07, 1, 1.6);
-    const enemyCount = Phaser.Math.Clamp(5 + Math.floor(this.winStreak / 2), 5, 7);
+    // Keep the first run slightly more open so the player learns the crossing rhythm
+    // before later restarts return to the denser traffic pattern.
+    const enemyCount = Phaser.Math.Clamp(4 + Math.ceil(this.winStreak / 2), 4, 7);
     const xStart = 110;
     const xEnd = 470;
     const yStart = 92;


### PR DESCRIPTION
### What
Make the first run a little less dense by spawning 4 dragons instead of 5, then ramping back toward the existing traffic density on subsequent wins.

### Why
Gives new players a clearer opening attempt to learn the crossing rhythm before the game scales up.

### Notes
- Build: `./node_modules/.bin/vite build`
